### PR TITLE
Change `WorkspaceEdit` to use `documentChanges`

### DIFF
--- a/pylsp_rope/plugin.py
+++ b/pylsp_rope/plugin.py
@@ -140,7 +140,11 @@ def pylsp_execute_command(config, workspace, command, arguments):
     commands = {cmd.name: cmd for cmd in refactoring.Command.__subclasses__()}
 
     try:
-        return commands[command](workspace, **arguments[0])()
+        return commands[command](workspace, **arguments[0])(
+            # FIXME: Hardcode executeCommand to use WorkspaceEditWithChanges
+            #        We need to upgrade this at some point.
+            workspace_edit_format=["changes"],
+        )
     except Exception as exc:
         logger.exception(
             "Exception when doing workspace/executeCommand: %s",

--- a/pylsp_rope/project.py
+++ b/pylsp_rope/project.py
@@ -61,8 +61,11 @@ def convert_workspace_edit_document_changes_to_changes(
     workspace_edit: WorkspaceEditWithDocumentChanges,
 ) -> WorkspaceEditWithChanges:
     workspace_changeset: Dict[DocumentUri, List[TextEdit]] = {}
-    for change in (workspace_edit["documentChanges"] or []):
-        document_changes = workspace_changeset.setdefault(change["textDocument"]["uri"], [])
+    for change in workspace_edit["documentChanges"] or []:
+        document_changes = workspace_changeset.setdefault(
+            change["textDocument"]["uri"],
+            [],
+        )
         document_changes.extend(change["edits"])
 
     return {

--- a/pylsp_rope/refactoring.py
+++ b/pylsp_rope/refactoring.py
@@ -14,10 +14,12 @@ from rope.refactor import (
 
 from pylsp_rope import typing, commands
 from pylsp_rope.project import (
+    WorkspaceEditFormat,
     get_project,
     get_resource,
     get_resources,
     apply_rope_changeset,
+    DEFAULT_WORKSPACE_EDIT_FORMAT,
 )
 from pylsp_rope.typing import DocumentUri, CodeActionKind
 
@@ -32,10 +34,20 @@ class Command:
         self.arguments = arguments
         self.__dict__.update(**arguments)
 
-    def __call__(self):
+    def __call__(
+        self,
+        *,
+        workspace_edit_format: List[
+            WorkspaceEditFormat
+        ] = DEFAULT_WORKSPACE_EDIT_FORMAT,
+    ):
         rope_changeset = self.get_changes()
         if rope_changeset is not None:
-            apply_rope_changeset(self.workspace, rope_changeset)
+            apply_rope_changeset(
+                self.workspace,
+                rope_changeset,
+                workspace_edit_format,
+            )
 
     def get_changes(self):
         """

--- a/pylsp_rope/refactoring.py
+++ b/pylsp_rope/refactoring.py
@@ -262,7 +262,11 @@ class CommandRefactorUseFunction(Command):
             resource=resource,
             offset=current_document.offset_at_position(self.position),
         )
-        resources = get_resources(self.workspace, self.documents) if self.documents is not None else None
+        resources = (
+            get_resources(self.workspace, self.documents)
+            if self.documents is not None
+            else None
+        )
         rope_changeset = refactoring.get_changes(
             resources=resources,
         )

--- a/pylsp_rope/text.py
+++ b/pylsp_rope/text.py
@@ -23,8 +23,7 @@ def Position(
     line: Tuple[AutoLineNumber, Optional[_CharNumberOrMarker]],
     *,
     _default_character: _CharNumberOrMarker = CharNumber(0),
-) -> typing.Position:
-    ...
+) -> typing.Position: ...
 
 
 @overload
@@ -32,24 +31,21 @@ def Position(
     line: AutoLineNumber,
     *,
     _default_character: _CharNumberOrMarker = CharNumber(0),
-) -> typing.Position:
-    ...
+) -> typing.Position: ...
 
 
 @overload
 def Position(
     line: AutoLineNumber,
     character: AutoCharNumber,
-) -> typing.Position:
-    ...
+) -> typing.Position: ...
 
 
 @overload
 def Position(
     line: AutoLineNumber,
     character: Literal["^", "$"],
-) -> typing.Position:
-    ...
+) -> typing.Position: ...
 
 
 def Position(

--- a/pylsp_rope/typing.py
+++ b/pylsp_rope/typing.py
@@ -45,14 +45,14 @@ class TextDocumentEdit(TypedDict):
 
 
 class WorkspaceEditWithChanges(TypedDict):
-    changes: Optional[Dict[DocumentUri, List[TextEdit]]]
+    changes: Dict[DocumentUri, List[TextEdit]]
     # documentChanges: Optional[list[TextDocumentEdit]]  # FIXME: should be: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]
     # changeAnnotations: ...
 
 
 class WorkspaceEditWithDocumentChanges(TypedDict):
     # changes: Optional[Dict[DocumentUri, List[TextEdit]]]
-    documentChanges: Optional[list[TextDocumentEdit]]  # FIXME: should be: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]
+    documentChanges: list[TextDocumentEdit]  # FIXME: should be: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]
     # changeAnnotations: ...
 
 
@@ -102,9 +102,3 @@ DocumentContent = NewType("DocumentContent", str)
 Line = NewType("Line", str)
 LineNumber = NewType("LineNumber", int)
 CharNumber = NewType("CharNumber", int)
-
-
-class SimpleWorkspaceEdit(TypedDict):
-    """This is identical to WorkspaceEdit, but `changes` field is not optional."""
-
-    changes: Dict[DocumentUri, List[TextEdit]]

--- a/pylsp_rope/typing.py
+++ b/pylsp_rope/typing.py
@@ -1,5 +1,5 @@
 import sys
-from typing import List, Dict, Optional, NewType, Any
+from typing import List, Dict, Optional, NewType, Any, Union
 
 
 if sys.version_info >= (3, 8):
@@ -25,15 +25,38 @@ class Range(TypedDict):
     end: Position
 
 
+class TextDocumentIdentifier(TypedDict):
+    uri: DocumentUri
+
+
+class OptionalVersionedTextDocumentIdentifier(TextDocumentIdentifier):
+    version: Optional[int]
+
+
 class TextEdit(TypedDict):
     range: Range
     newText: str
 
 
-class WorkspaceEdit(TypedDict):
+class TextDocumentEdit(TypedDict):
+    textDocument: OptionalVersionedTextDocumentIdentifier
+
+    edits: list[TextEdit]  # FIXME: should be: list[TextEdit| AnnotatedTextEdit]
+
+
+class WorkspaceEditWithChanges(TypedDict):
     changes: Optional[Dict[DocumentUri, List[TextEdit]]]
-    # documentChanges: ...
+    # documentChanges: Optional[list[TextDocumentEdit]]  # FIXME: should be: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]
     # changeAnnotations: ...
+
+
+class WorkspaceEditWithDocumentChanges(TypedDict):
+    # changes: Optional[Dict[DocumentUri, List[TextEdit]]]
+    documentChanges: Optional[list[TextDocumentEdit]]  # FIXME: should be: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]
+    # changeAnnotations: ...
+
+
+WorkspaceEdit = Union[WorkspaceEditWithChanges, WorkspaceEditWithDocumentChanges]
 
 
 class ApplyWorkspaceEditParams(TypedDict):

--- a/pylsp_rope/typing.py
+++ b/pylsp_rope/typing.py
@@ -1,5 +1,6 @@
 import sys
 from typing import List, Dict, Optional, NewType, Any, Union
+from typing_extensions import TypeGuard
 
 
 if sys.version_info >= (3, 8):
@@ -57,6 +58,14 @@ class WorkspaceEditWithDocumentChanges(TypedDict):
 
 
 WorkspaceEdit = Union[WorkspaceEditWithChanges, WorkspaceEditWithDocumentChanges]
+
+
+def is_workspace_edit_with_changes(workspace_edit: WorkspaceEdit) -> TypeGuard[WorkspaceEditWithChanges]:
+    return "changes" in workspace_edit
+
+
+def is_workspace_edit_with_document_changes(workspace_edit: WorkspaceEdit) -> TypeGuard[WorkspaceEditWithDocumentChanges]:
+    return "documentChanges" in workspace_edit
 
 
 class ApplyWorkspaceEditParams(TypedDict):

--- a/pylsp_rope/typing.py
+++ b/pylsp_rope/typing.py
@@ -1,6 +1,9 @@
 import sys
 from typing import List, Dict, Optional, NewType, Any, Union
-from typing_extensions import TypeGuard
+try:
+    from typing import TypeGuard
+except ImportError:
+    from typing_extensions import TypeGuard
 
 
 if sys.version_info >= (3, 8):

--- a/pylsp_rope/typing.py
+++ b/pylsp_rope/typing.py
@@ -41,7 +41,7 @@ class TextEdit(TypedDict):
 class TextDocumentEdit(TypedDict):
     textDocument: OptionalVersionedTextDocumentIdentifier
 
-    edits: list[TextEdit]  # FIXME: should be: list[TextEdit| AnnotatedTextEdit]
+    edits: List[TextEdit]  # FIXME: should be: list[TextEdit| AnnotatedTextEdit]
 
 
 class WorkspaceEditWithChanges(TypedDict):
@@ -52,7 +52,7 @@ class WorkspaceEditWithChanges(TypedDict):
 
 class WorkspaceEditWithDocumentChanges(TypedDict):
     # changes: Optional[Dict[DocumentUri, List[TextEdit]]]
-    documentChanges: list[TextDocumentEdit]  # FIXME: should be: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]
+    documentChanges: List[TextDocumentEdit]  # FIXME: should be: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]
     # changeAnnotations: ...
 
 

--- a/pylsp_rope/typing.py
+++ b/pylsp_rope/typing.py
@@ -53,18 +53,24 @@ class WorkspaceEditWithChanges(TypedDict):
 
 class WorkspaceEditWithDocumentChanges(TypedDict):
     # changes: Optional[Dict[DocumentUri, List[TextEdit]]]
-    documentChanges: List[TextDocumentEdit]  # FIXME: should be: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]
+    documentChanges: List[
+        TextDocumentEdit
+    ]  # FIXME: should be: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]
     # changeAnnotations: ...
 
 
 WorkspaceEdit = Union[WorkspaceEditWithChanges, WorkspaceEditWithDocumentChanges]
 
 
-def is_workspace_edit_with_changes(workspace_edit: WorkspaceEdit) -> TypeGuard[WorkspaceEditWithChanges]:
+def is_workspace_edit_with_changes(
+    workspace_edit: WorkspaceEdit,
+) -> TypeGuard[WorkspaceEditWithChanges]:
     return "changes" in workspace_edit
 
 
-def is_workspace_edit_with_document_changes(workspace_edit: WorkspaceEdit) -> TypeGuard[WorkspaceEditWithDocumentChanges]:
+def is_workspace_edit_with_document_changes(
+    workspace_edit: WorkspaceEdit,
+) -> TypeGuard[WorkspaceEditWithDocumentChanges]:
     return "documentChanges" in workspace_edit
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 install_requires = 
     python-lsp-server
     rope>=0.21.0
-    typing-extensions; python_version < '3.8'
+    typing-extensions; python_version < '3.10'
 
 python_requires = >= 3.6
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -11,7 +11,7 @@ from pylsp_rope.typing import (
     CodeAction,
     DocumentContent,
     DocumentUri,
-    SimpleWorkspaceEdit,
+    WorkspaceEditWithChanges,
     TextEdit,
 )
 from test.conftest import read_fixture_file
@@ -49,7 +49,7 @@ def assert_single_document_edit(
     return document_edits
 
 
-def assert_is_apply_edit_request(edit_request: Any) -> SimpleWorkspaceEdit:
+def assert_is_apply_edit_request(edit_request: Any) -> WorkspaceEditWithChanges:
     assert edit_request == call(
         "workspace/applyEdit",
         {
@@ -59,7 +59,7 @@ def assert_is_apply_edit_request(edit_request: Any) -> SimpleWorkspaceEdit:
         },
     )
 
-    workspace_edit: SimpleWorkspaceEdit = edit_request[0][1]["edit"]
+    workspace_edit: WorkspaceEditWithChanges = edit_request[0][1]["edit"]
     for document_uri, document_edits in workspace_edit["changes"].items():
         assert is_document_uri(document_uri)
         for change in document_edits:
@@ -79,14 +79,14 @@ def is_document_uri(uri: DocumentUri) -> bool:
 
 
 def assert_modified_documents(
-    workspace_edit: SimpleWorkspaceEdit,
+    workspace_edit: WorkspaceEditWithChanges,
     document_uris: Collection[DocumentUri],
 ) -> None:
     assert workspace_edit["changes"].keys() == set(document_uris)
 
 
 def assert_unmodified_document(
-    workspace_edit: SimpleWorkspaceEdit,
+    workspace_edit: WorkspaceEditWithChanges,
     document_uri: DocumentUri,
 ) -> None:
     assert is_document_uri(document_uri)

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -5,7 +5,10 @@ from pylsp_rope.project import (
     get_resource,
     rope_changeset_to_workspace_edit,
 )
-from pylsp_rope.typing import is_workspace_edit_with_changes, is_workspace_edit_with_document_changes
+from pylsp_rope.typing import (
+    is_workspace_edit_with_changes,
+    is_workspace_edit_with_document_changes,
+)
 from test.conftest import create_document
 
 
@@ -45,7 +48,7 @@ def test_rope_changeset_to_workspace_changeset_changes(workspace):
 
     assert is_workspace_edit_with_changes(workspace_edit)
     assert workspace_edit["changes"] == {
-        document.uri: EXPECTED_EDITS
+        document.uri: EXPECTED_EDITS,
     }
 
 
@@ -61,11 +64,11 @@ def test_rope_changeset_to_workspace_changeset_document_changes(workspace):
     assert is_workspace_edit_with_document_changes(workspace_edit)
     assert workspace_edit["documentChanges"] == [
         {
-            'textDocument': {
-                'uri': document.uri,
-                'version': None,
+            "textDocument": {
+                "uri": document.uri,
+                "version": None,
             },
-            'edits': EXPECTED_EDITS,
+            "edits": EXPECTED_EDITS,
         },
     ]
 

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -5,44 +5,69 @@ from pylsp_rope.project import (
     get_resource,
     rope_changeset_to_workspace_edit,
 )
-from pylsp_rope.typing import is_workspace_edit_with_changes
+from pylsp_rope.typing import is_workspace_edit_with_changes, is_workspace_edit_with_document_changes
 from test.conftest import create_document
 
 
-def test_rope_changeset_to_workspace_changeset(workspace):
+EXPECTED_EDITS = [
+    {
+        "range": {
+            "start": {"line": 2, "character": 0},
+            "end": {"line": 3, "character": 0},
+        },
+        "newText": "",
+    },
+    {
+        "range": {
+            "start": {"line": 4, "character": 0},
+            "end": {"line": 5, "character": 0},
+        },
+        "newText": 'print("world")\n',
+    },
+    {
+        "range": {
+            "start": {"line": 15, "character": 0},
+            "end": {"line": 16, "character": 0},
+        },
+        "newText": '    os.path.join("world", roses)\n',
+    },
+]
+
+
+def test_rope_changeset_to_workspace_changeset_changes(workspace):
     document = create_document(workspace, "many_changes.py")
     rope_changeset = get_rope_changeset(workspace, document)
     workspace_edit = rope_changeset_to_workspace_edit(
         workspace,
         rope_changeset,
+        workspace_edit_format=["changes"],
     )
 
     assert is_workspace_edit_with_changes(workspace_edit)
     assert workspace_edit["changes"] == {
-        document.uri: [
-            {
-                "range": {
-                    "start": {"line": 2, "character": 0},
-                    "end": {"line": 3, "character": 0},
-                },
-                "newText": "",
-            },
-            {
-                "range": {
-                    "start": {"line": 4, "character": 0},
-                    "end": {"line": 5, "character": 0},
-                },
-                "newText": 'print("world")\n',
-            },
-            {
-                "range": {
-                    "start": {"line": 15, "character": 0},
-                    "end": {"line": 16, "character": 0},
-                },
-                "newText": '    os.path.join("world", roses)\n',
-            },
-        ]
+        document.uri: EXPECTED_EDITS
     }
+
+
+def test_rope_changeset_to_workspace_changeset_document_changes(workspace):
+    document = create_document(workspace, "many_changes.py")
+    rope_changeset = get_rope_changeset(workspace, document)
+    workspace_edit = rope_changeset_to_workspace_edit(
+        workspace,
+        rope_changeset,
+        workspace_edit_format=["documentChanges"],
+    )
+
+    assert is_workspace_edit_with_document_changes(workspace_edit)
+    assert workspace_edit["documentChanges"] == [
+        {
+            'textDocument': {
+                'uri': document.uri,
+                'version': None,
+            },
+            'edits': EXPECTED_EDITS,
+        },
+    ]
 
 
 def get_rope_changeset(workspace, document):

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -5,6 +5,7 @@ from pylsp_rope.project import (
     get_resource,
     rope_changeset_to_workspace_edit,
 )
+from pylsp_rope.typing import is_workspace_edit_with_changes
 from test.conftest import create_document
 
 
@@ -16,6 +17,7 @@ def test_rope_changeset_to_workspace_changeset(workspace):
         rope_changeset,
     )
 
+    assert is_workspace_edit_with_changes(workspace_edit)
     assert workspace_edit["changes"] == {
         document.uri: [
             {


### PR DESCRIPTION
There are two variants of `WorkspaceEdit`, this change generates the `WorkspaceEdit.documentChanges` and converts it to `changes` for clients that doesn't support `documentChanges`.

Whether a client supports versioned document edits is expressed via wworkspace.workspaceEdit.documentChanges` client capability.

