### PR TITLE
fix(inline): do not offer changeless inline refactor, backed by test

### DIFF
--- a/pylsp_rope/refactoring.py
+++ b/pylsp_rope/refactoring.py
@@ -221,11 +221,14 @@ class CommandRefactorInline(Command):
     position: typing.Range
 
     def validate(self, info):
-        inline.create_inline(
+        refactoring = inline.create_inline(
             project=self.project,
             resource=info.resource,
             offset=info.current_document.offset_at_position(info.position),
         )
+        rope_changeset = refactoring.get_changes()
+        if not rope_changeset.changes:
+            raise Exception("Not offering changeless inline refactor")
 
     def get_changes(self):
         current_document, resource = get_resource(self.workspace, self.document_uri)

--- a/test/test_inline.py
+++ b/test/test_inline.py
@@ -77,3 +77,25 @@ def test_inline_not_offered_when_selecting_unsuitable_range(
         response,
         command=commands.COMMAND_REFACTOR_INLINE,
     )
+
+
+def test_inline_not_offered_when_selecting_function_parameter(
+    config, workspace, code_action_context
+):
+    document = create_document(workspace, "simple_extract_method.py")
+    line = 10
+    start_col = end_col = document.lines[line].index("a")
+    selection = Range((line, start_col), (line, end_col))
+
+    response = plugin.pylsp_code_actions(
+        config=config,
+        workspace=workspace,
+        document=document,
+        range=selection,
+        context=code_action_context,
+    )
+
+    assert_code_actions_do_not_offer(
+        response,
+        command=commands.COMMAND_REFACTOR_INLINE,
+    )


### PR DESCRIPTION
Hi!

I am using pylsp rope as an extension in vscode and encountered a situation where inline refactor is offered on a function parameter, which (I think) is not valid for inlining.

I have added a test to verify the issue and created a fix.

I thought fixing it here is more appropriate than in `rope` itself since technically there is nothing wrong with an empty refactor, it is simply not interesting to offer from the language server point-of-view.

Please let me know if I should change anything!